### PR TITLE
fix: add newline when writing memory entries

### DIFF
--- a/utils/fileHandler.js
+++ b/utils/fileHandler.js
@@ -13,8 +13,7 @@ const readMemory = async (topic) => {
 
 const writeMemory = async (topic, text) => {
     const filePath = path.join(__dirname, "..", "data", `${topic}.txt`);
-    const line = `[${new Date().toISOString()}] ${text}
-`;
+    const line = `[${new Date().toISOString()}] ${text}\n`;
     await fs.appendFile(filePath, line);
 };
 


### PR DESCRIPTION
## Summary
- ensure `writeMemory` adds a newline when appending entries

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897adde581c833299980c079e4c4368