### PR TITLE
Add web panel and API key middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/middleware/authApiKey.js
+++ b/middleware/authApiKey.js
@@ -1,0 +1,19 @@
+// middleware/authApiKey.js
+module.exports = function authApiKey(req, res, next) {
+  if (req.path === '/status' || req.path === '/panel') return next();
+
+  const key = process.env.API_KEY;
+  if (!key) {
+    if (!authApiKey.warned) {
+      console.warn('API_KEY not set; skipping auth');
+      authApiKey.warned = true;
+    }
+    return next();
+  }
+
+  const auth = req.get('Authorization');
+  if (auth !== `Bearer ${key}`) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+  next();
+};

--- a/server.js
+++ b/server.js
@@ -9,10 +9,16 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use(require('./middleware/authApiKey'));
 
 // status/health
 app.get('/status', (req, res) => {
   res.json({ status: 'ok', uptime: process.uptime() });
+});
+
+// prosty panel HTML
+app.get('/panel', (req, res) => {
+  res.sendFile(path.join(process.cwd(), 'views', 'panel.html'));
 });
 
 // router pamięci

--- a/views/panel.html
+++ b/views/panel.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Memory AI Panel</title>
+</head>
+<body>
+  <h1>Memory AI Panel</h1>
+
+  <div>
+    <label>Adres serwera: <input id="server" placeholder="http://localhost:3000" /></label>
+    <label>API Key: <input id="apiKey" placeholder="optional" /></label>
+  </div>
+
+  <h2>Send Text to Memory</h2>
+  <form id="form-text">
+    <label>Topic: <input name="topic" required /></label>
+    <label>Text: <input name="text" required /></label>
+    <button type="submit">Send</button>
+  </form>
+  <pre id="out-text"></pre>
+
+  <h2>Upload File to Local Memory</h2>
+  <form id="form-upload-local" enctype="multipart/form-data">
+    <input type="file" name="file" required />
+    <button type="submit">Upload</button>
+  </form>
+  <pre id="out-local"></pre>
+
+  <h2>Upload File to Google Drive</h2>
+  <form id="form-upload-gdrive" enctype="multipart/form-data">
+    <input type="file" name="file" required />
+    <button type="submit">Upload to GDrive</button>
+  </form>
+  <pre id="out-gdrive"></pre>
+
+  <script>
+    function baseUrl() {
+      return document.getElementById('server').value.replace(/\/$/, '') || '';
+    }
+    function authHeader() {
+      const key = document.getElementById('apiKey').value.trim();
+      return key ? { 'Authorization': 'Bearer ' + key } : {};
+    }
+
+    document.getElementById('form-text').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const f = e.target;
+      const topic = encodeURIComponent(f.topic.value.trim());
+      const text = f.text.value;
+      const res = await fetch(`${baseUrl()}/memory/${topic}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader() },
+        body: JSON.stringify({ text })
+      });
+      document.getElementById('out-text').textContent = await res.text();
+    });
+
+    document.getElementById('form-upload-local').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const f = e.target;
+      const fd = new FormData(f);
+      const res = await fetch(`${baseUrl()}/memory/upload`, {
+        method: 'POST',
+        headers: authHeader(),
+        body: fd
+      });
+      document.getElementById('out-local').textContent = await res.text();
+    });
+
+    document.getElementById('form-upload-gdrive').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const f = e.target;
+      const fd = new FormData(f);
+      const res = await fetch(`${baseUrl()}/upload-gdrive`, {
+        method: 'POST',
+        headers: authHeader(),
+        body: fd
+      });
+      document.getElementById('out-gdrive').textContent = await res.text();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add HTML panel with forms for text memory, local uploads, and Google Drive uploads
- Implement API key middleware skipping /status and /panel routes
- Wire middleware and panel route into server

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c6855c1148332bd465a158f790857