### PR TITLE
Add endpoint testing scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,29 @@ Serwer Express.js do zapisywania notatek i przesyłania plików z GPTs do Google
 - `GET /memory/:topic` – odczytuje notatki
 - `POST /upload-gdrive` – przesyła plik do folderu "Dane-Memory AI mini" na Google Drive
 
+## Testowanie endpointów
+
+W katalogu `scripts` znajdują się przykładowe skrypty do sprawdzenia działania API:
+
+- `scripts/test_endpoints.sh` – wersja Bash dla systemów Unix
+- `scripts/test_endpoints.bat` – wersja dla Windows
+
+Użycie (domyślne URL):
+
+```bash
+bash scripts/test_endpoints.sh
+scripts\test_endpoints.bat
+```
+
+Można również podać własny URL i opcjonalny klucz API:
+
+```bash
+bash scripts/test_endpoints.sh http://localhost:3000 MÓJ_KLUCZ
+scripts\test_endpoints.bat http://localhost:3000 MÓJ_KLUCZ
+```
+
+Skrypty wykonują `GET /status`, `POST /memory/notes`, `GET /memory/notes`, `POST /memory/upload` oraz `POST /upload-gdrive` (ten ostatni zwykle zwraca `501`, jeśli Google Drive nie jest skonfigurowane).
+
 ## Deploy na Render
 
 1. Wgraj projekt na GitHub.

--- a/scripts/test_endpoints.bat
+++ b/scripts/test_endpoints.bat
@@ -1,0 +1,37 @@
+@echo off
+REM Simple script to test API endpoints for Memory AI mini server.
+REM Usage: test_endpoints.bat [base_url] [api_key]
+REM base_url defaults to https://memory-ai-mini-gdrive-v2.onrender.com
+
+set "BASE_URL=%~1"
+if "%BASE_URL%"=="" set "BASE_URL=https://memory-ai-mini-gdrive-v2.onrender.com"
+set "API_KEY=%~2"
+set "AUTH_HEADER="
+if not "%API_KEY%"=="" set "AUTH_HEADER=-H \"Authorization: Bearer %API_KEY%\""
+
+echo Base URL: %BASE_URL%
+if not "%API_KEY%"=="" echo Using API key authentication
+
+echo.
+echo GET /status
+curl -s -w "\nHTTP %%{http_code}\n" "%BASE_URL%/status"
+
+echo.
+echo POST /memory/notes
+curl -s -w "\nHTTP %%{http_code}\n" -X POST "%BASE_URL%/memory/notes" ^
+  -H "Content-Type: application/json" %AUTH_HEADER% ^
+  -d "{\"text\":\"test from script\"}"
+
+echo.
+echo GET /memory/notes
+curl -s -w "\nHTTP %%{http_code}\n" "%BASE_URL%/memory/notes" %AUTH_HEADER%
+
+echo.
+echo POST /memory/upload
+curl -s -w "\nHTTP %%{http_code}\n" -X POST "%BASE_URL%/memory/upload" ^
+  -F "file=@README.md" %AUTH_HEADER%
+
+echo.
+echo POST /upload-gdrive (expect 501 if not configured)
+curl -s -w "\nHTTP %%{http_code}\n" -X POST "%BASE_URL%/upload-gdrive" ^
+  -F "file=@README.md" %AUTH_HEADER%

--- a/scripts/test_endpoints.sh
+++ b/scripts/test_endpoints.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Simple script to test API endpoints for Memory AI mini server.
+# Usage: ./test_endpoints.sh [base_url] [api_key]
+# base_url defaults to https://memory-ai-mini-gdrive-v2.onrender.com
+
+set -euo pipefail
+
+BASE_URL="${1:-https://memory-ai-mini-gdrive-v2.onrender.com}"
+API_KEY="${2:-}"
+
+AUTH_HEADER=()
+if [[ -n "$API_KEY" ]]; then
+  AUTH_HEADER=(-H "Authorization: Bearer $API_KEY")
+fi
+
+echo "Base URL: $BASE_URL"
+if [[ -n "$API_KEY" ]]; then
+  echo "Using API key authentication"
+fi
+
+echo
+echo "GET /status"
+curl -sS -w "\nHTTP %{http_code}\n" "$BASE_URL/status"
+
+echo
+echo "POST /memory/notes"
+curl -sS -w "\nHTTP %{http_code}\n" -X POST "$BASE_URL/memory/notes" \
+  -H "Content-Type: application/json" "${AUTH_HEADER[@]}" \
+  -d '{"text":"test from script"}'
+
+echo
+echo "GET /memory/notes"
+curl -sS -w "\nHTTP %{http_code}\n" "$BASE_URL/memory/notes" "${AUTH_HEADER[@]}"
+
+echo
+echo "POST /memory/upload"
+curl -sS -w "\nHTTP %{http_code}\n" -X POST "$BASE_URL/memory/upload" \
+  -F "file=@README.md" "${AUTH_HEADER[@]}"
+
+echo
+echo "POST /upload-gdrive (expect 501 if not configured)"
+curl -sS -w "\nHTTP %{http_code}\n" -X POST "$BASE_URL/upload-gdrive" \
+  -F "file=@README.md" "${AUTH_HEADER[@]}"


### PR DESCRIPTION
## Summary
- add bash and Windows scripts to exercise server endpoints
- document endpoint test scripts in README

## Testing
- `npm test`
- `bash scripts/test_endpoints.sh` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689c685ec1e08332bb21755755b5ea03