### PR TITLE
docs: add panel, auth, and drive usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,105 @@
-
 # 🧠 Memory AI – Google Drive Upload
 
-Serwer Express.js do zapisywania notatek i przesyłania plików z GPTs do Google Drive.
+Minimal Express.js service for storing text "memories" and optionally uploading
+files to Google Drive.
 
-## Uruchomienie
+## Running
 
-1. Zainstaluj zależności: `npm install`
-2. Uruchom serwer: `npm start`
+1. Install dependencies: `npm install`
+2. Start the server: `npm start`
 
-## Endpointy
+## Panel
 
-- `POST /memory/:topic` – zapisuje notatkę do tematu
-- `GET /memory/:topic` – odczytuje notatki
-- `POST /upload-gdrive` – przesyła plik do folderu "Dane-Memory AI mini" na Google Drive
+A small web panel is served from **`/panel`**. It lets you browse topics, read
+saved notes, append new text and try file uploads without writing code. Open it
+in a browser while the server is running.
 
-## Deploy na Render
+## Authorization
 
-1. Wgraj projekt na GitHub.
-2. Utwórz Web Service na Render.com.
-3. W ustawieniach serwisu ustaw **Build Command** na `npm ci` oraz **Start Command** na `npm start`.
-4. Dodaj `client_secret.json` i `token.json` jako **Secret Files**.
-5. Kliknij Deploy.
+Set the `API_KEY` environment variable to require a shared secret:
+
+```bash
+export API_KEY=secret
+npm start
+```
+
+Every request must then supply the key via the `x-api-key` header:
+
+```bash
+curl -H "x-api-key: $API_KEY" http://localhost:3000/status
+```
+
+## Google Drive
+
+File uploads are stored locally by default. To also push them to Google Drive:
+
+1. enable the feature: `GDRIVE_ENABLED=1`
+2. provide credentials with `CLIENT_SECRET_JSON` (raw JSON or base64) or by
+   placing a `client_secret.json` file in the project root
+
+When enabled, upload responses include Drive metadata for the created file. If
+Drive is disabled or credentials are missing, uploads complete locally and the
+response omits Drive fields.
+
+## Endpoints & cURL examples
+
+Assuming the server runs on `http://localhost:3000` and `API_KEY` contains your
+key:
+
+### `GET /status`
+
+Health check.
+
+```bash
+curl -H "x-api-key: $API_KEY" http://localhost:3000/status
+```
+
+### `POST /memory/:topic`
+
+Append a line of text to a topic.
+
+```bash
+curl -H "x-api-key: $API_KEY" -H "Content-Type: application/json" \
+     -d '{"text":"Hello"}' \
+     http://localhost:3000/memory/test
+```
+
+### `GET /memory/:topic`
+
+Read all lines for a topic.
+
+```bash
+curl -H "x-api-key: $API_KEY" http://localhost:3000/memory/test
+```
+
+### `POST /memory/upload`
+
+Upload a file (stored in `data/` and optionally on Google Drive).
+
+```bash
+curl -H "x-api-key: $API_KEY" -F "file=@README.md" \
+     http://localhost:3000/memory/upload
+```
+
+## Testing with scripts
+
+Helper scripts issue the above requests using `curl`:
+
+```bash
+bash scripts/test_endpoints.sh
+# or on Windows
+scripts\test_endpoints.bat
+```
+
+Set `BASE_URL` or `API_KEY` environment variables before running to override
+defaults.
+
+## Deploy on Render
+
+1. Push the project to GitHub.
+2. Create a Web Service on Render.com.
+3. In service settings set **Build Command** to `npm ci` and **Start Command**
+   to `npm start`.
+4. Add `client_secret.json` and `token.json` as **Secret Files**.
+5. Click Deploy.
 

--- a/scripts/test_endpoints.bat
+++ b/scripts/test_endpoints.bat
@@ -1,0 +1,28 @@
+@echo off
+setlocal
+
+if "%BASE_URL%"=="" (
+  set "BASE_URL=http://localhost:3000"
+)
+
+if not "%API_KEY%"=="" (
+  set "HEADER=-H x-api-key:%API_KEY%"
+)
+
+echo GET /status
+curl -s %HEADER% %BASE_URL%/status
+echo.
+
+echo POST /memory/test
+curl -s %HEADER% -H "Content-Type: application/json" -d "{\"text\":\"hello from script\"}" %BASE_URL%/memory/test
+echo.
+
+echo GET /memory/test
+curl -s %HEADER% %BASE_URL%/memory/test
+echo.
+
+echo POST /memory/upload
+curl -s %HEADER% -F "file=@README.md" %BASE_URL%/memory/upload
+echo.
+
+endlocal

--- a/scripts/test_endpoints.sh
+++ b/scripts/test_endpoints.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Basic smoke tests for the API endpoints.
+
+BASE_URL=${BASE_URL:-http://localhost:3000}
+AUTH_HEADER=""
+if [ -n "$API_KEY" ]; then
+  AUTH_HEADER="-H x-api-key:$API_KEY"
+fi
+
+echo "GET /status"
+curl -s $AUTH_HEADER "$BASE_URL/status"
+echo
+
+echo "POST /memory/test"
+curl -s $AUTH_HEADER -H "Content-Type: application/json" \
+  -d '{"text":"hello from script"}' "$BASE_URL/memory/test"
+echo
+
+echo "GET /memory/test"
+curl -s $AUTH_HEADER "$BASE_URL/memory/test"
+echo
+
+echo "POST /memory/upload"
+curl -s $AUTH_HEADER -F "file=@README.md" "$BASE_URL/memory/upload"
+echo


### PR DESCRIPTION
## Summary
- describe `/panel` web UI and its features
- document API key header and Google Drive env vars
- add cURL examples and helper scripts for exercising endpoints

## Testing
- `npm test`
- `bash scripts/test_endpoints.sh` *(upload step returned `text-required`)*

------
https://chatgpt.com/codex/tasks/task_e_689c68629250833299286acc42907244