### PR TITLE
feat: add API key authentication middleware

### DIFF
--- a/middleware/authApiKey.js
+++ b/middleware/authApiKey.js
@@ -1,0 +1,24 @@
+let warned = false;
+
+module.exports = (req, res, next) => {
+  const { path } = req;
+  if (path === '/status' || path.startsWith('/panel')) {
+    return next();
+  }
+
+  const apiKey = process.env.API_KEY;
+  if (!apiKey) {
+    if (!warned) {
+      console.warn('API_KEY is not set; bypassing auth');
+      warned = true;
+    }
+    return next();
+  }
+
+  const authHeader = req.get('authorization');
+  if (!authHeader || authHeader !== `Bearer ${apiKey}`) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+
+  next();
+};

--- a/server.js
+++ b/server.js
@@ -15,6 +15,9 @@ app.get('/status', (req, res) => {
   res.json({ status: 'ok', uptime: process.uptime() });
 });
 
+// API key auth middleware
+app.use(require('./middleware/authApiKey'));
+
 // router pamięci
 const memoryRoutes = require('./routes/memoryRoutes');
 app.use('/memory', memoryRoutes);


### PR DESCRIPTION
## Summary
- add authApiKey middleware to validate Authorization Bearer token and skip status/panel routes
- apply API key middleware before API routers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c68c974a0833295c5df4e6cd85a19