### PR TITLE
feat: add Google Drive upload endpoint

### DIFF
--- a/routes/gdriveRoutes.js
+++ b/routes/gdriveRoutes.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const path = require('path');
+const fs = require('fs/promises');
+const fssync = require('fs');
+const multer = require('multer');
+const { getDriveClient, ensureFolder, uploadFile } = require('../utils/googleDrive');
+
+const router = express.Router();
+const TMP_DIR = path.join(process.cwd(), 'data', '_gdrive');
+if (!fssync.existsSync(TMP_DIR)) fssync.mkdirSync(TMP_DIR, { recursive: true });
+const upload = multer({ dest: TMP_DIR });
+
+router.post('/upload-gdrive', upload.single('file'), async (req, res) => {
+  if (process.env.GDRIVE_ENABLED !== '1') {
+    return res.status(501).json({ error: 'gdrive-disabled' });
+  }
+  if (!req.file) return res.status(400).json({ error: 'file-required' });
+
+  const tempPath = req.file.path;
+  try {
+    const drive = await getDriveClient();
+    const folderId = await ensureFolder(drive, 'Dane-Memory AI mini');
+    const result = await uploadFile(drive, tempPath, folderId);
+    res.json({ ok: true, fileId: result.id, name: result.name });
+  } catch (err) {
+    console.error('gdrive upload error:', err);
+    res.status(500).json({ error: 'upload-failed', details: String(err.message || err) });
+  } finally {
+    try {
+      await fs.unlink(tempPath);
+    } catch (_) {}
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -19,6 +19,10 @@ app.get('/status', (req, res) => {
 const memoryRoutes = require('./routes/memoryRoutes');
 app.use('/memory', memoryRoutes);
 
+// Google Drive upload
+const gdriveRoutes = require('./routes/gdriveRoutes');
+app.use(gdriveRoutes);
+
 // start
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/utils/googleDrive.js
+++ b/utils/googleDrive.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const { google } = require('googleapis');
+
+async function getDriveClient() {
+  let jsonStr = process.env.CLIENT_SECRET_JSON || '';
+  if (jsonStr) {
+    try {
+      const maybe = Buffer.from(jsonStr, 'base64').toString('utf8');
+      if (maybe.trim().startsWith('{')) jsonStr = maybe;
+    } catch (_) {}
+  }
+  let creds;
+  if (jsonStr) {
+    creds = JSON.parse(jsonStr);
+  } else {
+    const filePath = path.join(process.cwd(), 'client_secret.json');
+    creds = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  }
+  const auth = new google.auth.GoogleAuth({
+    credentials: creds,
+    scopes: ['https://www.googleapis.com/auth/drive.file'],
+  });
+  return google.drive({ version: 'v3', auth });
+}
+
+async function ensureFolder(drive, name) {
+  const q = `name='${name.replace(/'/g, "\\'")}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
+  const res = await drive.files.list({ q, fields: 'files(id,name)' });
+  if (res.data.files && res.data.files.length > 0) {
+    return res.data.files[0].id;
+  }
+  const folder = await drive.files.create({
+    resource: { name, mimeType: 'application/vnd.google-apps.folder' },
+    fields: 'id',
+  });
+  return folder.data.id;
+}
+
+async function uploadFile(drive, filePath, folderId) {
+  const fileName = path.basename(filePath);
+  const fileMetadata = { name: fileName };
+  if (folderId) fileMetadata.parents = [folderId];
+  const media = { body: fs.createReadStream(filePath) };
+  const res = await drive.files.create({
+    resource: fileMetadata,
+    media,
+    fields: 'id,name',
+  });
+  return { id: res.data.id, name: res.data.name };
+}
+
+module.exports = { getDriveClient, ensureFolder, uploadFile };


### PR DESCRIPTION
## Summary
- add Google Drive utility for obtaining Drive client, ensuring folder, and uploading files
- expose POST `/upload-gdrive` that uploads a file to Drive and cleans up temp files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c68cc632083328d7e7f4500ebd35a