### PR TITLE
Add API endpoint testing scripts

### DIFF
--- a/scripts/test_endpoints.bat
+++ b/scripts/test_endpoints.bat
@@ -1,0 +1,64 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "BASE=%1"
+if "%BASE%"=="" set "BASE=https://memory-ai-mini-gdrive-v2.onrender.com"
+set "API_KEY=%2"
+
+set "AUTH="
+if not "%API_KEY%"=="" set "AUTH=-H \"Authorization: Bearer %API_KEY%\""
+
+echo Testing API at %BASE%
+
+echo 1. GET /status
+for /f "delims=" %%A in ('curl -s -o NUL -w "%%{http_code}" %BASE%/status') do set "CODE=%%A"
+echo /status -> %CODE%
+if not "%CODE%"=="200" (
+  echo Expected 200
+  exit /b 1
+)
+
+echo 2. POST /memory/notes and verify
+set "NOTE=Test note %RANDOM%"
+for /f "delims=" %%A in ('curl -s -o NUL -w "%%{http_code}" %AUTH% -d "text=!NOTE!" %BASE%/memory/notes') do set "CODE=%%A"
+echo POST /memory/notes -> %CODE%
+if not "%CODE%"=="200" (
+  echo Failed to post note
+  exit /b 1
+)
+curl -s %AUTH% %BASE%/memory/notes > tmp_notes.txt
+findstr /C:"!NOTE!" tmp_notes.txt >nul
+if errorlevel 1 (
+  echo Note not found
+  del tmp_notes.txt
+  exit /b 1
+)
+del tmp_notes.txt
+echo Verified note appended.
+
+echo 3. POST /memory/upload
+echo sample upload>tmp_upload.txt
+for /f "delims=" %%A in ('curl -s -o NUL -w "%%{http_code}" %AUTH% -F "file=@tmp_upload.txt" %BASE%/memory/upload') do set "CODE=%%A"
+del tmp_upload.txt
+echo POST /memory/upload -> %CODE%
+if not "%CODE%"=="200" (
+  echo Memory upload failed
+  exit /b 1
+)
+
+echo 4. POST /upload-gdrive
+echo sample upload>tmp_gd.txt
+for /f "delims=" %%A in ('curl -s -o NUL -w "%%{http_code}" %AUTH% -F "file=@tmp_gd.txt" %BASE%/upload-gdrive') do set "CODE=%%A"
+del tmp_gd.txt
+echo POST /upload-gdrive -> %CODE%
+if "%CODE%"=="200" (
+  echo GDrive upload succeeded
+) else if "%CODE%"=="501" (
+  echo GDrive disabled
+) else (
+  echo Unexpected status: %CODE%
+  exit /b 1
+)
+
+echo All tests completed.
+exit /b 0

--- a/scripts/test_endpoints.sh
+++ b/scripts/test_endpoints.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE="${1:-https://memory-ai-mini-gdrive-v2.onrender.com}"
+API_KEY="${2:-}"
+
+AUTH_HEADER=()
+if [ -n "$API_KEY" ]; then
+  AUTH_HEADER=(-H "Authorization: Bearer $API_KEY")
+fi
+
+echo "Testing API at $BASE"
+
+# 1. GET /status
+status_code=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/status")
+echo "/status -> $status_code"
+if [ "$status_code" -ne 200 ]; then
+  echo "Expected 200 from /status" >&2
+  exit 1
+fi
+
+# 2. POST /memory/notes and verify
+note="test note $(date +%s)"
+status_code=$(curl -s -o /dev/null -w "%{http_code}" "${AUTH_HEADER[@]}" --data-urlencode "text=$note" "$BASE/memory/notes")
+echo "POST /memory/notes -> $status_code"
+if [ "$status_code" -ne 200 ]; then
+  echo "Failed to post note" >&2
+  exit 1
+fi
+content=$(curl -s "${AUTH_HEADER[@]}" "$BASE/memory/notes")
+echo "$content" | grep -F "$note" >/dev/null || { echo "Note not found" >&2; exit 1; }
+echo "Verified note appended."
+
+# 3. POST /memory/upload
+tmpfile=$(mktemp)
+echo "sample upload" > "$tmpfile"
+status_code=$(curl -s -o /dev/null -w "%{http_code}" "${AUTH_HEADER[@]}" -F "file=@$tmpfile" "$BASE/memory/upload")
+rm -f "$tmpfile"
+echo "POST /memory/upload -> $status_code"
+if [ "$status_code" -ne 200 ]; then
+  echo "Memory upload failed" >&2
+  exit 1
+fi
+
+# 4. POST /upload-gdrive
+tmpfile=$(mktemp)
+echo "sample upload" > "$tmpfile"
+status_code=$(curl -s -o /dev/null -w "%{http_code}" "${AUTH_HEADER[@]}" -F "file=@$tmpfile" "$BASE/upload-gdrive")
+rm -f "$tmpfile"
+echo "POST /upload-gdrive -> $status_code"
+if [ "$status_code" -eq 200 ]; then
+  echo "GDrive upload succeeded"
+elif [ "$status_code" -eq 501 ]; then
+  echo "GDrive disabled"
+else
+  echo "Unexpected status: $status_code" >&2
+  exit 1
+fi
+
+echo "All tests completed."


### PR DESCRIPTION
## Summary
- add bash script to test core endpoints with optional API key
- add Windows batch script for equivalent endpoint tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c68d21d9883329b38bacfd83b2786