### PR TITLE
Add CI/CD workflow with smoke tests

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,35 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  BASE_URL: ${{ secrets.BASE_URL || 'https://memory-ai-mini-gdrive-v2.onrender.com' }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Trigger Render deploy
+        run: curl -fsS -X POST "${{ secrets.RENDER_DEPLOY_HOOK }}"
+      - name: Wait for deployment
+        run: |
+          for i in {1..5}; do
+            echo "poll $i"
+            if curl -fsS "$BASE_URL/status" >/dev/null 2>&1; then
+              break
+            fi
+            sleep 5
+          done
+      - name: Smoke tests
+        run: |
+          bash scripts/smoke.sh "$BASE_URL" "${{ secrets.API_KEY }}" | tee smoke.log
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-log
+          path: smoke.log

--- a/README.md
+++ b/README.md
@@ -22,3 +22,21 @@ Serwer Express.js do zapisywania notatek i przesyłania plików z GPTs do Google
 4. Dodaj `client_secret.json` i `token.json` jako **Secret Files**.
 5. Kliknij Deploy.
 
+## CI/CD
+
+Automatyczne wdrożenie na Render z prostymi smoke testami.
+
+### Sekrety GitHub
+
+W repozytorium ustaw sekrety (Settings → Secrets and variables → Actions):
+
+```
+RENDER_DEPLOY_HOOK = <Render Deploy Hook URL>
+BASE_URL           = https://memory-ai-mini-gdrive-v2.onrender.com
+(opcjonalnie) API_KEY = <twój klucz, jeśli włączony>
+```
+
+### Ręczne uruchomienie
+
+Przejdź do zakładki **Actions**, wybierz workflow **CI/CD** i kliknij **Run workflow**.
+

--- a/scripts/smoke.bat
+++ b/scripts/smoke.bat
@@ -1,0 +1,27 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "BASE_URL=%~1"
+if "%BASE_URL%"=="" set "BASE_URL=%BASE_URL%"
+if "%BASE_URL%"=="" (
+  echo BASE_URL required
+  exit /b 1
+)
+set "API_KEY=%~2"
+if "%API_KEY%"=="" set "API_KEY=%API_KEY%"
+
+echo HEAD %BASE_URL%/panel
+curl -fsSI "%BASE_URL%/panel" >nul || exit /b 1
+
+echo GET %BASE_URL%/status
+for /f "delims=" %%A in ('curl -fsS "%BASE_URL%/status"') do set "RESP=%%A"
+echo !RESP! | node -e "JSON.parse(require('fs').readFileSync(0,'utf8'))" >nul || exit /b 1
+
+if not "%API_KEY%"=="" (
+  echo POST %BASE_URL%/memory/notes
+  for /f "delims=" %%A in ('curl -fsS -H "Authorization: Bearer %API_KEY%" -H "Content-Type: application/json" -d {} "%BASE_URL%/memory/notes"') do set "RESP=%%A"
+  echo !RESP! | node -e "process.exit(JSON.parse(require('fs').readFileSync(0,'utf8')).ok===true?0:1)" >nul || exit /b 1
+)
+
+echo ok
+exit /b 0

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${1:-${BASE_URL:-}}"
+API_KEY="${2:-${API_KEY:-}}"
+
+log(){ echo "[smoke] $*"; }
+
+if [ -z "$BASE_URL" ]; then
+  echo "BASE_URL required" >&2
+  exit 1
+fi
+
+log "HEAD $BASE_URL/panel"
+curl -fsSI "$BASE_URL/panel" >/dev/null
+
+log "GET  $BASE_URL/status"
+STATUS=$(curl -fsS "$BASE_URL/status")
+# ensure response is valid JSON
+printf '%s' "$STATUS" | node -e "JSON.parse(require('fs').readFileSync(0,'utf8'))" >/dev/null
+
+if [ -n "$API_KEY" ]; then
+  log "POST $BASE_URL/memory/notes"
+  RESP=$(curl -fsS -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" -d '{}' "$BASE_URL/memory/notes")
+  printf '%s' "$RESP" | node -e "process.exit(JSON.parse(require('fs').readFileSync(0,'utf8')).ok===true?0:1)"
+fi
+
+log "ok"


### PR DESCRIPTION
## Summary
- add GitHub Actions CI/CD workflow to trigger Render deploy, poll for readiness and run smoke tests
- introduce cross-platform smoke test scripts for API endpoints
- document CI/CD setup and secrets in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c70e6d58c8332ba78d4b077280fff