### PR TITLE
Log OpenAPI path on server startup

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,5 +22,6 @@ app.use('/memory', memoryRoutes);
 // start
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
+  console.log('[api] OpenAPI served at /.well-known/openapi.yaml');
   console.log(`Server listening on ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- Log the OpenAPI endpoint location during server startup alongside the existing listening message.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c744d538c8332ace6428d9c538547