### PR TITLE
docs: document OpenAPI availability check

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,21 @@ Serwer Express.js do zapisywania notatek i przesyłania plików z GPTs do Google
 3. W ustawieniach serwisu ustaw **Build Command** na `npm ci` oraz **Start Command** na `npm start`.
 4. Dodaj `client_secret.json` i `token.json` jako **Secret Files**.
 5. Kliknij Deploy.
+6. Po wdrożeniu sprawdź specyfikację OpenAPI:
+
+   ```bash
+   curl -I https://<host>/.well-known/openapi.yaml
+   ```
+
+   Oczekiwany wynik: `200 OK`.
+
+## Testowanie
+
+Po każdym wdrożeniu możesz potwierdzić dostępność specyfikacji OpenAPI tym samym poleceniem:
+
+```bash
+curl -I https://<host>/.well-known/openapi.yaml
+```
+
+Powinno zwrócić status `200 OK`.
 


### PR DESCRIPTION
## Summary
- document `curl -I https://<host>/.well-known/openapi.yaml` to verify OpenAPI spec availability
- add testing section guiding maintainers to expect `200 OK`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c7450efbc833285c62972597380f7