### PR TITLE
feat: serve OpenAPI at well-known path

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,6 +5,18 @@ const path = require('path');
 
 const app = express();
 
+// OpenAPI spec
+app.get('/.well-known/openapi.yaml', (_req, res) => {
+  res.type('text/yaml');
+  res.sendFile(path.join(process.cwd(), 'openapi.yaml'));
+});
+
+// optional shorter path
+app.get('/openapi.yaml', (_req, res) => {
+  res.type('text/yaml');
+  res.sendFile(path.join(process.cwd(), 'openapi.yaml'));
+});
+
 // middleware
 app.use(cors());
 app.use(express.json());
@@ -22,5 +34,6 @@ app.use('/memory', memoryRoutes);
 // start
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
+  console.log('[api] OpenAPI served at /.well-known/openapi.yaml');
   console.log(`Server listening on ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- serve `openapi.yaml` from `/.well-known/openapi.yaml` and `/openapi.yaml`
- log OpenAPI availability on startup

## Testing
- `npm test`
- `curl -I http://localhost:3000/.well-known/openapi.yaml`

------
https://chatgpt.com/codex/tasks/task_e_689c7c9d0d1c83329f3cca984b5a594d