### PR TITLE
Serve OpenAPI spec from .well-known path

### DIFF
--- a/public/.well-known/openapi.yaml
+++ b/public/.well-known/openapi.yaml
@@ -1,0 +1,57 @@
+
+openapi: 3.0.1
+info:
+  title: Memory AI Mini API
+  description: API do zapisu i odczytu danych oraz przesyłania plików do Google Drive.
+  version: '1.0'
+servers:
+  - url: https://twoja-domena.onrender.com
+paths:
+  /memory/{topic}:
+    get:
+      summary: Pobierz pamięć dla tematu
+      parameters:
+        - name: topic
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Zawartość pamięci
+    post:
+      summary: Zapisz nową notatkę
+      parameters:
+        - name: topic
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                newText:
+                  type: string
+      responses:
+        '200':
+          description: Notatka zapisana
+  /upload-gdrive:
+    post:
+      summary: Prześlij plik na Google Drive
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: Plik przesłany

--- a/server.js
+++ b/server.js
@@ -9,6 +9,12 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+app.use('/.well-known', express.static(path.join(process.cwd(), 'public', '.well-known')));
+
+app.get('/.well-known/openapi.yaml', (_req, res) => {
+  res.type('text/yaml');
+  res.sendFile(path.join(process.cwd(), 'public', '.well-known', 'openapi.yaml'));
+});
 
 // status/health
 app.get('/status', (req, res) => {
@@ -23,4 +29,5 @@ app.use('/memory', memoryRoutes);
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
   console.log(`Server listening on ${PORT}`);
+  console.log('[api] OpenAPI at /.well-known/openapi.yaml');
 });


### PR DESCRIPTION
## Summary
- serve public/.well-known as static for OpenAPI specs
- add fallback route for `/.well-known/openapi.yaml`
- log location of OpenAPI spec on startup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c81c40e2c83328442e4d72a753903