### PR TITLE
Add panel upload page and route

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,6 +19,10 @@ app.get('/status', (req, res) => {
 const memoryRoutes = require('./routes/memoryRoutes');
 app.use('/memory', memoryRoutes);
 
+app.get('/panel', (_req, res) =>
+  res.sendFile(path.join(process.cwd(), 'views', 'panel.html'))
+);
+
 // start
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/views/panel.html
+++ b/views/panel.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Memory Panel</title>
+</head>
+<body>
+  <h1>Memory Panel</h1>
+
+  <section>
+    <h2>JSON POST to /memory/:topic</h2>
+    <form id="jsonForm">
+      <label>Topic: <input type="text" id="topic" required /></label><br />
+      <label>Text:<br /><textarea id="text" required></textarea></label><br />
+      <button type="submit">Send</button>
+    </form>
+    <pre id="jsonResult"></pre>
+  </section>
+
+  <section>
+    <h2>Upload file to /memory/upload</h2>
+    <form action="/memory/upload" method="post" enctype="multipart/form-data">
+      <input type="file" name="file" required />
+      <button type="submit">Upload</button>
+    </form>
+  </section>
+
+  <section>
+    <h2>Upload file to /upload-gdrive</h2>
+    <form action="/upload-gdrive" method="post" enctype="multipart/form-data">
+      <input type="file" name="file" required />
+      <button type="submit">Upload</button>
+    </form>
+  </section>
+
+  <script>
+    document.getElementById('jsonForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const topic = document.getElementById('topic').value.trim();
+      const text = document.getElementById('text').value.trim();
+      const res = await fetch('/memory/' + encodeURIComponent(topic), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text })
+      });
+      const out = await res.text();
+      document.getElementById('jsonResult').textContent = out;
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `/panel` endpoint serving new panel.html
- include forms for JSON notes and file uploads

## Testing
- `npm test`
- `node server.js & curl -i http://localhost:3000/panel`


------
https://chatgpt.com/codex/tasks/task_e_689c8b81f34083328e42b560f139bad5