### PR TITLE
feat: add API key middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Serwer Express.js do zapisywania notatek i przesyłania plików z GPTs do Google
 - `GET /memory/:topic` – odczytuje notatki
 - `POST /upload-gdrive` – przesyła plik do folderu "Dane-Memory AI mini" na Google Drive
 
+> Jeśli ustawisz zmienną środowiskową `API_KEY`, wszystkie
+> ścieżki poza `/status`, `/panel` oraz `/.well-known/*` będą wymagały
+> nagłówka `X-API-Key` lub parametru `api_key` z odpowiednią wartością.
+
 ## Deploy na Render
 
 1. Wgraj projekt na GitHub.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -55,3 +55,11 @@ paths:
       responses:
         '200':
           description: Plik przesłany
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+security:
+  - ApiKeyAuth: []

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const cors = require('cors');
 const path = require('path');
+require('dotenv').config();
 
 const app = express();
 
@@ -10,10 +11,31 @@ app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-// status/health
+// public routes
 app.get('/status', (req, res) => {
   res.json({ status: 'ok', uptime: process.uptime() });
 });
+
+// simple panel placeholder
+app.get('/panel', (req, res) => {
+  res.send('panel');
+});
+
+// serve any .well-known resources
+app.use('/.well-known', express.static(path.join(process.cwd(), '.well-known')));
+
+// API-key middleware (applied after public routes)
+function requireApiKey(req, res, next) {
+  const expected = process.env.API_KEY;
+  if (!expected) return next();
+
+  const provided = req.get('x-api-key') || req.query.api_key;
+  if (provided === expected) return next();
+
+  res.status(401).json({ error: 'unauthorized' });
+}
+
+app.use(requireApiKey);
 
 // router pamięci
 const memoryRoutes = require('./routes/memoryRoutes');


### PR DESCRIPTION
## Summary
- add API key middleware protecting routes
- expose status, panel and well-known paths without auth
- document API key requirement in README and OpenAPI spec

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c8b85fee08332ad905a3ce94aab05