### PR TITLE
Add Google Drive upload route

### DIFF
--- a/routes/driveRoutes.js
+++ b/routes/driveRoutes.js
@@ -1,0 +1,35 @@
+// routes/driveRoutes.js
+const express = require('express');
+const path = require('path');
+const fs = require('fs');
+const multer = require('multer');
+
+const memoryRoutes = require('./memoryRoutes');
+const getDriveOptional = memoryRoutes.getDriveOptional;
+
+const router = express.Router();
+const UPLOAD_DIR = path.join(process.cwd(), 'data', '_gdrive');
+fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+const upload = multer({ dest: UPLOAD_DIR });
+
+router.post('/upload', upload.single('file'), async (req, res) => {
+  try {
+    if (!req.file) return res.status(400).json({ error: 'file-required' });
+
+    const drive = await getDriveOptional();
+    if (!drive) return res.status(501).json({ error: 'drive-disabled' });
+
+    const fileMetadata = { name: req.file.originalname || req.file.filename };
+    const media = { mimeType: req.file.mimetype, body: fs.createReadStream(req.file.path) };
+    const result = await drive.files.create({ resource: fileMetadata, media, fields: 'id, name' });
+
+    fs.promises.unlink(req.file.path).catch(() => {});
+
+    res.json({ ok: true, file: result.data });
+  } catch (err) {
+    console.error('drive upload error:', err);
+    res.status(500).json({ error: 'upload-failed', details: String(err.message || err) });
+  }
+});
+
+module.exports = router;

--- a/routes/memoryRoutes.js
+++ b/routes/memoryRoutes.js
@@ -132,4 +132,5 @@ router.post('/upload', upload.single('file'), async (req, res) => {
   }
 });
 
+router.getDriveOptional = getDriveOptional;
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -19,6 +19,10 @@ app.get('/status', (req, res) => {
 const memoryRoutes = require('./routes/memoryRoutes');
 app.use('/memory', memoryRoutes);
 
+// drive upload
+const driveRoutes = require('./routes/driveRoutes');
+app.use('/drive', driveRoutes);
+
 // start
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- expose Drive helper in memory routes for reuse
- add dedicated Drive upload router handling multipart uploads and forwarding to Google Drive
- wire new router into server to provide `/drive/upload`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c8b894c9883328811fdf2c19cdecd