### PR TITLE
Mount panel and OpenAPI docs

### DIFF
--- a/public/.well-known/openapi.yaml
+++ b/public/.well-known/openapi.yaml
@@ -1,0 +1,57 @@
+
+openapi: 3.0.1
+info:
+  title: Memory AI Mini API
+  description: API do zapisu i odczytu danych oraz przesyłania plików do Google Drive.
+  version: '1.0'
+servers:
+  - url: https://twoja-domena.onrender.com
+paths:
+  /memory/{topic}:
+    get:
+      summary: Pobierz pamięć dla tematu
+      parameters:
+        - name: topic
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Zawartość pamięci
+    post:
+      summary: Zapisz nową notatkę
+      parameters:
+        - name: topic
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                newText:
+                  type: string
+      responses:
+        '200':
+          description: Notatka zapisana
+  /upload-gdrive:
+    post:
+      summary: Prześlij plik na Google Drive
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: Plik przesłany

--- a/server.js
+++ b/server.js
@@ -10,6 +10,23 @@ app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
+// panel
+app.get('/panel', (_req, res) =>
+  res.sendFile(path.join(process.cwd(), 'views', 'panel.html'))
+);
+
+// OpenAPI
+app.use(
+  '/.well-known',
+  express.static(path.join(process.cwd(), 'public', '.well-known'))
+);
+app.get('/.well-known/openapi.yaml', (_req, res) => {
+  res.type('text/yaml');
+  res.sendFile(
+    path.join(process.cwd(), 'public', '.well-known', 'openapi.yaml')
+  );
+});
+
 // status/health
 app.get('/status', (req, res) => {
   res.json({ status: 'ok', uptime: process.uptime() });
@@ -22,5 +39,6 @@ app.use('/memory', memoryRoutes);
 // start
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
+  console.log('[server] panel + openapi mounted');
   console.log(`Server listening on ${PORT}`);
 });

--- a/views/panel.html
+++ b/views/panel.html
@@ -1,0 +1,1 @@
+Panel OK


### PR DESCRIPTION
## Summary
- serve /panel with placeholder HTML
- expose OpenAPI spec under /.well-known and log when mounted

## Testing
- `npm test`
- `curl -I http://localhost:3000/panel`
- `curl -I http://localhost:3000/.well-known/openapi.yaml`


------
https://chatgpt.com/codex/tasks/task_e_689c8ff25080833290a1f6a3a94e819d