### PR TITLE
Document auth and endpoints in OpenAPI spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,15 +1,42 @@
-
 openapi: 3.0.1
 info:
   title: Memory AI Mini API
   description: API do zapisu i odczytu danych oraz przesyłania plików do Google Drive.
   version: '1.0'
 servers:
-  - url: https://twoja-domena.onrender.com
+  - url: https://memory-ai-mini-gdrive-v2.onrender.com # placeholder
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+security:
+  - bearerAuth: []
 paths:
+  /status:
+    get:
+      summary: Check service status
+      operationId: getStatus
+      security: []
+      responses:
+        '200':
+          description: Service status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+                  uptime:
+                    type: number
+                    description: Seconds since server start
   /memory/{topic}:
     get:
-      summary: Pobierz pamięć dla tematu
+      summary: Retrieve memory for a topic
+      operationId: getMemory
       parameters:
         - name: topic
           in: path
@@ -18,9 +45,25 @@ paths:
             type: string
       responses:
         '200':
-          description: Zawartość pamięci
+          description: Topic memory as plain text
+          content:
+            text/plain:
+              schema:
+                type: string
+        '500':
+          description: Read failed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  details:
+                    type: string
     post:
-      summary: Zapisz nową notatkę
+      summary: Append a new memory entry
+      operationId: addMemory
       parameters:
         - name: topic
           in: path
@@ -33,25 +76,145 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - text
               properties:
-                newText:
+                text:
                   type: string
       responses:
         '200':
-          description: Notatka zapisana
-  /upload-gdrive:
+          description: Entry stored
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  bytes:
+                    type: integer
+        '400':
+          description: Missing text
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+        '500':
+          description: Write failed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  details:
+                    type: string
+  /memory/upload:
     post:
-      summary: Prześlij plik na Google Drive
+      summary: Upload a file to local memory storage
+      operationId: uploadMemoryFile
       requestBody:
         required: true
         content:
           multipart/form-data:
             schema:
               type: object
+              required:
+                - file
               properties:
                 file:
                   type: string
                   format: binary
       responses:
         '200':
-          description: Plik przesłany
+          description: File stored
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  stored:
+                    type: string
+        '400':
+          description: File required
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+        '500':
+          description: Upload failed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  details:
+                    type: string
+  /upload-gdrive:
+    post:
+      summary: Upload a file to Google Drive
+      operationId: uploadGdrive
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: File uploaded to Google Drive
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  id:
+                    type: string
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+        '501':
+          description: Google Drive integration disabled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+        '500':
+          description: Upload failed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  details:
+                    type: string


### PR DESCRIPTION
## Summary
- add JWT bearer auth scheme and global security to OpenAPI
- document /status, /memory, /memory/upload, and /upload-gdrive endpoints
- note render URL placeholder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c9710e74c833282b7dd04157a2e8d