### PR TITLE
Serve OpenAPI spec from .well-known

### DIFF
--- a/public/.well-known/openapi.yaml
+++ b/public/.well-known/openapi.yaml
@@ -1,0 +1,57 @@
+
+openapi: 3.0.1
+info:
+  title: Memory AI Mini API
+  description: API do zapisu i odczytu danych oraz przesyłania plików do Google Drive.
+  version: '1.0'
+servers:
+  - url: https://twoja-domena.onrender.com
+paths:
+  /memory/{topic}:
+    get:
+      summary: Pobierz pamięć dla tematu
+      parameters:
+        - name: topic
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Zawartość pamięci
+    post:
+      summary: Zapisz nową notatkę
+      parameters:
+        - name: topic
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                newText:
+                  type: string
+      responses:
+        '200':
+          description: Notatka zapisana
+  /upload-gdrive:
+    post:
+      summary: Prześlij plik na Google Drive
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: Plik przesłany

--- a/server.js
+++ b/server.js
@@ -10,6 +10,13 @@ app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
+// OpenAPI spec
+app.use('/.well-known', express.static(path.join(process.cwd(), 'public', '.well-known')));
+app.get('/.well-known/openapi.yaml', (_req, res) => {
+  res.type('text/yaml');
+  res.sendFile(path.join(process.cwd(), 'public', '.well-known', 'openapi.yaml'));
+});
+
 // status/health
 app.get('/status', (req, res) => {
   res.json({ status: 'ok', uptime: process.uptime() });


### PR DESCRIPTION
## Summary
- Copy root `openapi.yaml` into `public/.well-known/` for a standardized discovery location.
- Serve the spec via new Express static middleware and explicit route.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c971665e483328677c3b440e25190