### PR TITLE
Enhance status endpoint with resource checks

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const cors = require('cors');
 const path = require('path');
+const fs = require('fs');
 
 const app = express();
 
@@ -12,7 +13,13 @@ app.use(express.urlencoded({ extended: true }));
 
 // status/health
 app.get('/status', (req, res) => {
-  res.json({ status: 'ok', uptime: process.uptime() });
+  res.json({
+    status: 'ok',
+    uptime: process.uptime(),
+    hasPanel: fs.existsSync(path.join(process.cwd(), 'views', 'panel.html')),
+    hasOpenAPI: fs.existsSync(path.join(process.cwd(), 'public', '.well-known', 'openapi.yaml')),
+    version: process.env.npm_package_version,
+  });
 });
 
 // router pamięci


### PR DESCRIPTION
## Summary
- include `fs` import
- expand `/status` to report panel and OpenAPI availability and version

## Testing
- `npm test`
- `curl -s http://localhost:3000/status; echo`

------
https://chatgpt.com/codex/tasks/task_e_689c971b886c8332bef84a773725584f