### PR TITLE
feat: add API key auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Serwer Express.js do zapisywania notatek i przesyłania plików z GPTs do Google
 ## Uruchomienie
 
 1. Zainstaluj zależności: `npm install`
-2. Uruchom serwer: `npm start`
+2. Ustaw zmienną środowiskową `API_KEY` (np. `export API_KEY=twoj_klucz`)
+3. Uruchom serwer: `npm start`
+4. Wysyłaj żądania z nagłówkiem `Authorization: Bearer <API_KEY>`
 
 ## Endpointy
 
@@ -19,6 +21,7 @@ Serwer Express.js do zapisywania notatek i przesyłania plików z GPTs do Google
 1. Wgraj projekt na GitHub.
 2. Utwórz Web Service na Render.com.
 3. W ustawieniach serwisu ustaw **Build Command** na `npm ci` oraz **Start Command** na `npm start`.
-4. Dodaj `client_secret.json` i `token.json` jako **Secret Files**.
-5. Kliknij Deploy.
+4. Dodaj zmienną środowiskową `API_KEY` z własnym sekretnym kluczem.
+5. Dodaj `client_secret.json` i `token.json` jako **Secret Files**.
+6. Kliknij Deploy.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6,6 +6,15 @@ info:
   version: '1.0'
 servers:
   - url: https://twoja-domena.onrender.com
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API_KEY
+      description: Użyj nagłówka `Authorization: Bearer <API_KEY>`
+security:
+  - ApiKeyAuth: []
 paths:
   /memory/{topic}:
     get:

--- a/server.js
+++ b/server.js
@@ -10,6 +10,14 @@ app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
+const API_KEY = process.env.API_KEY;
+app.use((req, res, next) => {
+  if (req.path.startsWith('/.well-known') || req.path === '/status') return next();
+  const auth = req.get('Authorization') || '';
+  if (API_KEY && auth === `Bearer ${API_KEY}`) return next();
+  res.status(401).json({ error: 'unauthorized' });
+});
+
 // status/health
 app.get('/status', (req, res) => {
   res.json({ status: 'ok', uptime: process.uptime() });


### PR DESCRIPTION
## Summary
- protect routes with optional API key middleware
- document API_KEY usage for local and Render deployments
- expose bearer security scheme in OpenAPI spec

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c9725ea70833298f33ed993af11bf