### PR TITLE
docs: add GPT actions setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ Serwer Express.js do zapisywania notatek i przesyłania plików z GPTs do Google
 
 ## Endpointy
 
+- `GET /status` – status serwera
 - `POST /memory/:topic` – zapisuje notatkę do tematu
 - `GET /memory/:topic` – odczytuje notatki
+- `POST /memory/upload` – przesyła plik do lokalnej pamięci
 - `POST /upload-gdrive` – przesyła plik do folderu "Dane-Memory AI mini" na Google Drive
 
 ## Deploy na Render
@@ -21,4 +23,15 @@ Serwer Express.js do zapisywania notatek i przesyłania plików z GPTs do Google
 3. W ustawieniach serwisu ustaw **Build Command** na `npm ci` oraz **Start Command** na `npm start`.
 4. Dodaj `client_secret.json` i `token.json` jako **Secret Files**.
 5. Kliknij Deploy.
+
+## Connect to GPTs (Actions)
+
+1. Open **Actions** → Add from URL: `https://<host>/.well-known/openapi.yaml`
+2. Auth: Bearer → header `Authorization: Bearer {{API_KEY}}`
+3. Save the secret `API_KEY` equal to Render’s `API_KEY`
+4. Test: “Zapisz notatkę do tematu notes…”
+
+```bash
+curl -I https://<host>/.well-known/openapi.yaml
+```
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7,6 +7,12 @@ info:
 servers:
   - url: https://twoja-domena.onrender.com
 paths:
+  /status:
+    get:
+      summary: Sprawdź status serwera
+      responses:
+        '200':
+          description: Status serwera
   /memory/{topic}:
     get:
       summary: Pobierz pamięć dla tematu
@@ -39,6 +45,22 @@ paths:
       responses:
         '200':
           description: Notatka zapisana
+  /memory/upload:
+    post:
+      summary: Prześlij plik do lokalnej pamięci
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: Plik zapisany
   /upload-gdrive:
     post:
       summary: Prześlij plik na Google Drive


### PR DESCRIPTION
## Summary
- document `/status` and `/memory/upload` endpoints
- add "Connect to GPTs (Actions)" section with auth and test details
- provide quick curl example for the OpenAPI spec

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c97298e9c83328dab8461d42ceac7