### PR TITLE
Add authenticated Drive upload endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Serwer Express.js do zapisywania notatek i przesyłania plików z GPTs do Google
 
 - `POST /memory/:topic` – zapisuje notatkę do tematu
 - `GET /memory/:topic` – odczytuje notatki
-- `POST /upload-gdrive` – przesyła plik do folderu "Dane-Memory AI mini" na Google Drive
+- `POST /upload-gdrive` – przesyła plik do folderu "Dane-Memory AI mini" na Google Drive (wymaga nagłówka `Authorization: Bearer <token>`). Zwraca `id` i `name` przesłanego pliku; `401` przy błędnym tokenie; `501` gdy integracja z Drive wyłączona.
 
 ## Deploy na Render
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -42,6 +42,8 @@ paths:
   /upload-gdrive:
     post:
       summary: Prześlij plik na Google Drive
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -55,3 +57,15 @@ paths:
       responses:
         '200':
           description: Plik przesłany
+        '401':
+          description: Brak lub nieważny token Bearer
+        '501':
+          description: Integracja z Google Drive wyłączona
+        '500':
+          description: Inny błąd serwera
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: OAuth2

--- a/routes/memoryRoutes.js
+++ b/routes/memoryRoutes.js
@@ -132,4 +132,4 @@ router.post('/upload', upload.single('file'), async (req, res) => {
   }
 });
 
-module.exports = router;
+module.exports = { router, getDriveOptional };

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const cors = require('cors');
 const path = require('path');
+const multer = require('multer');
 
 const app = express();
 
@@ -16,8 +17,38 @@ app.get('/status', (req, res) => {
 });
 
 // router pamięci
-const memoryRoutes = require('./routes/memoryRoutes');
+const { router: memoryRoutes, getDriveOptional } = require('./routes/memoryRoutes');
 app.use('/memory', memoryRoutes);
+
+// uploader Drive
+const upload = multer({ storage: multer.memoryStorage() });
+app.post('/upload-gdrive', upload.single('file'), async (req, res) => {
+  try {
+    if (!req.file) return res.status(400).json({ error: 'file-required' });
+
+    const drive = await getDriveOptional();
+    if (!drive) return res.status(501).json({ error: 'drive-disabled' });
+
+    const authHeader = req.headers.authorization || '';
+    const match = authHeader.match(/^Bearer (.+)$/);
+    if (!match) return res.status(401).json({ error: 'bearer-required' });
+
+    drive._options.auth.setCredentials({ access_token: match[1] });
+
+    const result = await drive.files.create({
+      requestBody: { name: req.file.originalname || req.file.filename },
+      media: { mimeType: req.file.mimetype, body: req.file.buffer },
+    });
+
+    res.json({ ok: true, id: result.data.id, name: result.data.name });
+  } catch (err) {
+    console.error('gdrive upload error:', err);
+    if (err.code === 401 || err.status === 401) {
+      return res.status(401).json({ error: 'unauthorized' });
+    }
+    res.status(500).json({ error: 'upload-failed', details: String(err.message || err) });
+  }
+});
 
 // start
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- expose Google Drive upload route that validates bearer tokens and returns granular errors
- export optional Drive client helper for reuse
- document upload auth and responses in OpenAPI and README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c972166bc8332bae388e6f2365eb4