### PR TITLE
feat: add diagnostics to status handler

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const cors = require('cors');
 const path = require('path');
+const fs = require('fs');
 
 const app = express();
 
@@ -12,7 +13,18 @@ app.use(express.urlencoded({ extended: true }));
 
 // status/health
 app.get('/status', (req, res) => {
-  res.json({ status: 'ok', uptime: process.uptime() });
+  res.json({
+    status: 'ok',
+    uptime: process.uptime(),
+    hasPanel: fs.existsSync('views/panel.html'),
+    hasOpenAPI: fs.existsSync('public/.well-known/openapi.yaml'),
+    openapiPath: path.join(
+      process.cwd(),
+      'public',
+      '.well-known',
+      'openapi.yaml'
+    )
+  });
 });
 
 // router pamięci
@@ -22,5 +34,9 @@ app.use('/memory', memoryRoutes);
 // start
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
+  console.log('[diag]', {
+    hasPanel: fs.existsSync('views/panel.html'),
+    hasOpenAPI: fs.existsSync('public/.well-known/openapi.yaml')
+  });
   console.log(`Server listening on ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- extend `/status` to report panel and OpenAPI availability
- log panel/OpenAPI presence on startup for diagnostics

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cd98b55d48332aad72df4fa7b43a7